### PR TITLE
(+semver: breaking) remove stop id prefix

### DIFF
--- a/src/Syncromatics.Clients.HoustonMetro.Api/HoustonMetroClient.cs
+++ b/src/Syncromatics.Clients.HoustonMetro.Api/HoustonMetroClient.cs
@@ -22,10 +22,10 @@ namespace Syncromatics.Clients.HoustonMetro.Api
             _client = new RestClient(httpClient).For<IHoustonMetroApi>();
         }
 
-        public Task<Response<Arrival>> GetArrivalsAsync(int stopId) =>
+        public Task<Response<Arrival>> GetArrivalsAsync(string stopId) =>
             _client.GetArrivalsAsync(_settings.ApiKey, stopId);
 
-        public Task<Response<Route>> GetRoutesAsync(int stopId) =>
+        public Task<Response<Route>> GetRoutesAsync(string stopId) =>
             _client.GetRoutesAsync(_settings.ApiKey, stopId);
     }
 }

--- a/src/Syncromatics.Clients.HoustonMetro.Api/IHoustonMetroApi.cs
+++ b/src/Syncromatics.Clients.HoustonMetro.Api/IHoustonMetroApi.cs
@@ -9,14 +9,14 @@ namespace Syncromatics.Clients.HoustonMetro.Api
 {
     internal interface IHoustonMetroApi
     {
-        [Get("data/Stops('MeTrAuOfHaCo_{stopId}')/Arrivals?$format=json")]
+        [Get("data/Stops('{stopId}')/Arrivals?$format=json")]
         Task<Response<Arrival>> GetArrivalsAsync(
             [Header("Ocp-Apim-Subscription-Key")]string apiKey,
-            [Path]int stopId);
+            [Path]string stopId);
 
-        [Get("data/Stops('MeTrAuOfHaCo_{stopId}')/Routes?$format=json")]
+        [Get("data/Stops('{stopId}')/Routes?$format=json")]
         Task<Response<Route>> GetRoutesAsync(
             [Header("Ocp-Apim-Subscription-Key")]string apiKey,
-            [Path]int stopId);
+            [Path]string stopId);
     }
 }

--- a/src/Syncromatics.Clients.HoustonMetro.Api/IHoustonMetroClient.cs
+++ b/src/Syncromatics.Clients.HoustonMetro.Api/IHoustonMetroClient.cs
@@ -4,7 +4,7 @@ namespace Syncromatics.Clients.HoustonMetro.Api
 {
     public interface IHoustonMetroClient
     {
-        Task<Response<Arrival>> GetArrivalsAsync(int stopId);
-        Task<Response<Route>> GetRoutesAsync(int stopId);
+        Task<Response<Arrival>> GetArrivalsAsync(string stopId);
+        Task<Response<Route>> GetRoutesAsync(string stopId);
     }
 }

--- a/test/Syncromatics.Clients.HoustonMetro.Api.Tests/Integration/HoustonMetroClientTests.cs
+++ b/test/Syncromatics.Clients.HoustonMetro.Api.Tests/Integration/HoustonMetroClientTests.cs
@@ -22,14 +22,14 @@ namespace Syncromatics.Clients.HoustonMetro.Api.Tests.Integration
         }
 
         [Theory]
-        [InlineData(79)]
-        [InlineData(244)]
-        [InlineData(661)]
-        [InlineData(681)]
-        [InlineData(9045)]
-        [InlineData(9953)]
-        [InlineData(10055)]
-        public async Task ShouldGetArrivals(int stopId)
+        [InlineData("MeTrAuOfHaCo_79")]
+        [InlineData("MeTrAuOfHaCo_244")]
+        [InlineData("MeTrAuOfHaCo_661")]
+        [InlineData("MeTrAuOfHaCo_681")]
+        [InlineData("MeTrAuOfHaCo_9045")]
+        [InlineData("MeTrAuOfHaCo_9953")]
+        [InlineData("MeTrAuOfHaCo_10055")]
+        public async Task ShouldGetArrivals(string stopId)
         {
             Response<Arrival> result = null;
             await RetryPolicy().ExecuteAsync(async () =>
@@ -48,14 +48,14 @@ namespace Syncromatics.Clients.HoustonMetro.Api.Tests.Integration
         }
 
         [Theory]
-        [InlineData(79)]
-        [InlineData(244)]
-        [InlineData(661)]
-        [InlineData(681)]
-        [InlineData(9045)]
-        [InlineData(9953)]
-        [InlineData(10055)]
-        public async Task ShouldGetRoutes(int stopId)
+        [InlineData("MeTrAuOfHaCo_79")]
+        [InlineData("MeTrAuOfHaCo_244")]
+        [InlineData("MeTrAuOfHaCo_661")]
+        [InlineData("MeTrAuOfHaCo_681")]
+        [InlineData("MeTrAuOfHaCo_9045")]
+        [InlineData("MeTrAuOfHaCo_9953")]
+        [InlineData("MeTrAuOfHaCo_10055")]
+        public async Task ShouldGetRoutes(string stopId)
         {
             Response<Route> result = null;
             await RetryPolicy().ExecuteAsync(async () =>


### PR DESCRIPTION
(+semver: breaking) change the stop id to string to accept the various different prefixed stop ids that houston has.